### PR TITLE
Update patient search to support names, phone numbers, and age

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,9 @@ dependencies {
   androidTestImplementation "com.android.support.test:rules:$versions.supportTest"
   kaptAndroidTest "com.google.dagger:dagger-compiler:$versions.dagger"
 
+  debugImplementation "com.facebook.stetho:stetho:$versions.stetho"
+  debugImplementation "com.facebook.stetho:stetho-okhttp3:$versions.stetho"
+
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlin"
 
   implementation "com.android.support:appcompat-v7:$versions.supportLib"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,10 +61,13 @@ dependencies {
   testImplementation 'com.nhaarman:mockito-kotlin:1.5.0'
   testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
   testImplementation 'com.google.truth:truth:0.40'
-  androidTestImplementation 'com.google.truth:truth:0.40'
+  testImplementation 'com.github.blocoio:faker:1.2.7'
+
   androidTestImplementation 'com.android.support:support-annotations:27.1.1'
   androidTestImplementation "com.android.support.test:runner:$versions.supportTest"
   androidTestImplementation "com.android.support.test:rules:$versions.supportTest"
+  androidTestImplementation 'com.google.truth:truth:0.40'
+  androidTestImplementation 'com.github.blocoio:faker:1.2.7'
   kaptAndroidTest "com.google.dagger:dagger-compiler:$versions.dagger"
 
   debugImplementation "com.facebook.stetho:stetho:$versions.stetho"

--- a/app/src/androidTest/java/org/resolvetosavelives/red/di/TestAppComponent.kt
+++ b/app/src/androidTest/java/org/resolvetosavelives/red/di/TestAppComponent.kt
@@ -2,6 +2,7 @@ package org.resolvetosavelives.red.di
 
 import dagger.Component
 import org.resolvetosavelives.red.bp.sync.BloodPressureSyncAndroidTest
+import org.resolvetosavelives.red.patient.PatientRepositoryAndroidTest
 import org.resolvetosavelives.red.patient.PatientSyncAndroidTest
 
 @AppScope
@@ -9,5 +10,8 @@ import org.resolvetosavelives.red.patient.PatientSyncAndroidTest
 interface TestAppComponent : AppComponent {
 
   fun inject(target: PatientSyncAndroidTest)
+
   fun inject(target: BloodPressureSyncAndroidTest)
+
+  fun inject(target: PatientRepositoryAndroidTest)
 }

--- a/app/src/androidTest/java/org/resolvetosavelives/red/patient/PatientRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/resolvetosavelives/red/patient/PatientRepositoryAndroidTest.kt
@@ -1,7 +1,5 @@
 package org.resolvetosavelives.red.patient
 
-import android.arch.persistence.room.Room
-import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import org.junit.After
@@ -9,19 +7,22 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.resolvetosavelives.red.AppDatabase
+import org.resolvetosavelives.red.TestRedApp
 import org.threeten.bp.LocalDate
+import javax.inject.Inject
 
 @RunWith(AndroidJUnit4::class)
 class PatientRepositoryAndroidTest {
 
-  lateinit var patientRepository: PatientRepository
+  @Inject
+  lateinit var repository: PatientRepository
+
+  @Inject
   lateinit var database: AppDatabase
 
   @Before
   fun setUp() {
-    val context = InstrumentationRegistry.getTargetContext()
-    database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
-    patientRepository = PatientRepository(database)
+    TestRedApp.appComponent().inject(this)
   }
 
   @Test
@@ -32,18 +33,18 @@ class PatientRepositoryAndroidTest {
 
     val personalDetailsOnlyEntry = OngoingPatientEntry(personalDetails = ongoingPersonalDetails)
 
-    patientRepository.saveOngoingEntry(personalDetailsOnlyEntry)
-        .andThen(patientRepository.ongoingEntry())
+    repository.saveOngoingEntry(personalDetailsOnlyEntry)
+        .andThen(repository.ongoingEntry())
         .map { ongoingEntry -> ongoingEntry.copy(address = ongoingAddress) }
         .map { updatedEntry -> updatedEntry.copy(phoneNumber = ongoingPhoneNumber) }
-        .flatMapCompletable { withAddressAndPhoneNumbers -> patientRepository.saveOngoingEntry(withAddressAndPhoneNumbers) }
-        .andThen(patientRepository.saveOngoingEntryAsPatient())
+        .flatMapCompletable { withAddressAndPhoneNumbers -> repository.saveOngoingEntry(withAddressAndPhoneNumbers) }
+        .andThen(repository.saveOngoingEntryAsPatient())
         .subscribe()
 
-    val search1 = patientRepository.searchPatientsAndPhoneNumbers("lakshman").blockingFirst()
+    val search1 = repository.searchPatientsAndPhoneNumbers("lakshman").blockingFirst()
     assertThat(search1).isEmpty()
 
-    val search2 = patientRepository.searchPatientsAndPhoneNumbers("ashok").blockingFirst()
+    val search2 = repository.searchPatientsAndPhoneNumbers("ashok").blockingFirst()
     assertThat(search2).hasSize(1)
     assertThat(search2.first().age).isNull()
     assertThat(search2.first().dateOfBirth).isEqualTo(LocalDate.parse("1985-04-08"))
@@ -58,17 +59,17 @@ class PatientRepositoryAndroidTest {
 
     val personalDetailsOnlyEntry = OngoingPatientEntry(personalDetails = ongoingPersonalDetails)
 
-    patientRepository.saveOngoingEntry(personalDetailsOnlyEntry)
-        .andThen(patientRepository.ongoingEntry())
+    repository.saveOngoingEntry(personalDetailsOnlyEntry)
+        .andThen(repository.ongoingEntry())
         .map { ongoingEntry -> ongoingEntry.copy(address = ongoingAddress) }
-        .flatMapCompletable { withAddressAndPhoneNumbers -> patientRepository.saveOngoingEntry(withAddressAndPhoneNumbers) }
-        .andThen(patientRepository.saveOngoingEntryAsPatient())
+        .flatMapCompletable { withAddressAndPhoneNumbers -> repository.saveOngoingEntry(withAddressAndPhoneNumbers) }
+        .andThen(repository.saveOngoingEntryAsPatient())
         .subscribe()
 
-    val search1 = patientRepository.searchPatientsAndPhoneNumbers("lakshman").blockingFirst()
+    val search1 = repository.searchPatientsAndPhoneNumbers("lakshman").blockingFirst()
     assertThat(search1).isEmpty()
 
-    val search2 = patientRepository.searchPatientsAndPhoneNumbers("bima").blockingFirst()
+    val search2 = repository.searchPatientsAndPhoneNumbers("bima").blockingFirst()
     assertThat(search2).hasSize(1)
     assertThat(search2.first().age).isNull()
     assertThat(search2.first().dateOfBirth).isEqualTo(LocalDate.parse("1985-04-08"))
@@ -84,19 +85,19 @@ class PatientRepositoryAndroidTest {
 
       val personalDetailsOnlyEntry = OngoingPatientEntry(personalDetails = ongoingPersonalDetails)
 
-      patientRepository.saveOngoingEntry(personalDetailsOnlyEntry)
-          .andThen(patientRepository.ongoingEntry())
+      repository.saveOngoingEntry(personalDetailsOnlyEntry)
+          .andThen(repository.ongoingEntry())
           .map { ongoingEntry -> ongoingEntry.copy(address = ongoingAddress) }
           .map { updatedEntry -> updatedEntry.copy(phoneNumber = ongoingPhoneNumber) }
-          .flatMapCompletable { withAddressAndPhoneNumbers -> patientRepository.saveOngoingEntry(withAddressAndPhoneNumbers) }
-          .andThen(patientRepository.saveOngoingEntryAsPatient())
+          .flatMapCompletable { withAddressAndPhoneNumbers -> repository.saveOngoingEntry(withAddressAndPhoneNumbers) }
+          .andThen(repository.saveOngoingEntryAsPatient())
           .subscribe()
     }
 
-    val search1 = patientRepository.searchPatientsAndPhoneNumbers("9999").blockingFirst()
+    val search1 = repository.searchPatientsAndPhoneNumbers("9999").blockingFirst()
     assertThat(search1).isEmpty()
 
-    val search2 = patientRepository.searchPatientsAndPhoneNumbers("1712").blockingFirst()
+    val search2 = repository.searchPatientsAndPhoneNumbers("1712").blockingFirst()
     assertThat(search2).hasSize(5)
     assertThat(search2.first().phoneNumber).isEqualTo("17121988")
     assertThat(search2.first().phoneType).isEqualTo(PatientPhoneNumberType.LANDLINE)
@@ -110,18 +111,18 @@ class PatientRepositoryAndroidTest {
 
     val personalDetailsOnlyEntry = OngoingPatientEntry(personalDetails = ongoingPersonalDetails)
 
-    patientRepository.saveOngoingEntry(personalDetailsOnlyEntry)
-        .andThen(patientRepository.ongoingEntry())
+    repository.saveOngoingEntry(personalDetailsOnlyEntry)
+        .andThen(repository.ongoingEntry())
         .map { ongoingEntry -> ongoingEntry.copy(address = ongoingAddress) }
         .map { updatedEntry -> updatedEntry.copy(phoneNumber = ongoingPhoneNumber) }
-        .flatMapCompletable { withAddressAndPhoneNumbers -> patientRepository.saveOngoingEntry(withAddressAndPhoneNumbers) }
-        .andThen(patientRepository.saveOngoingEntryAsPatient())
+        .flatMapCompletable { withAddressAndPhoneNumbers -> repository.saveOngoingEntry(withAddressAndPhoneNumbers) }
+        .andThen(repository.saveOngoingEntryAsPatient())
         .subscribe()
 
-    val search1 = patientRepository.searchPatientsAndPhoneNumbers("lakshman").blockingFirst()
+    val search1 = repository.searchPatientsAndPhoneNumbers("lakshman").blockingFirst()
     assertThat(search1).isEmpty()
 
-    val search2 = patientRepository.searchPatientsAndPhoneNumbers("ashok").blockingFirst()
+    val search2 = repository.searchPatientsAndPhoneNumbers("ashok").blockingFirst()
     val patient = search2[0]
     assertThat(patient.fullName).isEqualTo("Ashok Kumar")
     assertThat(patient.dateOfBirth).isNull()
@@ -139,8 +140,8 @@ class PatientRepositoryAndroidTest {
         personalDetails = ongoingPersonalDetails,
         address = ongoingAddress)
 
-    patientRepository.saveOngoingEntry(ongoingPatientEntry)
-        .andThen(patientRepository.saveOngoingEntryAsPatient())
+    repository.saveOngoingEntry(ongoingPatientEntry)
+        .andThen(repository.saveOngoingEntryAsPatient())
         .test()
         .assertError(AssertionError::class.java)
   }
@@ -156,11 +157,11 @@ class PatientRepositoryAndroidTest {
         address = ongoingAddress,
         phoneNumber = ongoingPhoneNumber)
 
-    patientRepository.saveOngoingEntry(ongoingPatientEntry)
-        .andThen(patientRepository.saveOngoingEntryAsPatient())
+    repository.saveOngoingEntry(ongoingPatientEntry)
+        .andThen(repository.saveOngoingEntryAsPatient())
         .subscribe()
 
-    val combinedPatient = patientRepository.searchPatientsAndPhoneNumbers("kumar")
+    val combinedPatient = repository.searchPatientsAndPhoneNumbers("kumar")
         .blockingFirst()
         .first()
 

--- a/app/src/main/java/org/resolvetosavelives/red/AppDatabase.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/AppDatabase.kt
@@ -9,6 +9,7 @@ import org.resolvetosavelives.red.patient.Patient
 import org.resolvetosavelives.red.patient.PatientAddress
 import org.resolvetosavelives.red.patient.PatientPhoneNumber
 import org.resolvetosavelives.red.patient.PatientPhoneNumberType
+import org.resolvetosavelives.red.patient.PatientSearchResult
 import org.resolvetosavelives.red.patient.PatientStatus
 import org.resolvetosavelives.red.patient.PatientWithAddressAndPhone
 import org.resolvetosavelives.red.patient.SyncStatus
@@ -41,6 +42,8 @@ abstract class AppDatabase : RoomDatabase() {
   abstract fun phoneNumberDao(): PatientPhoneNumber.RoomDao
 
   abstract fun patientAddressPhoneDao(): PatientWithAddressAndPhone.RoomDao
+
+  abstract fun patientSearchDao(): PatientSearchResult.RoomDao
 
   abstract fun bloodPressureDao(): BloodPressureMeasurement.RoomDao
 }

--- a/app/src/main/java/org/resolvetosavelives/red/RedApp.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/RedApp.kt
@@ -1,6 +1,7 @@
 package org.resolvetosavelives.red
 
 import android.app.Application
+import com.facebook.stetho.Stetho
 import com.gabrielittner.threetenbp.LazyThreeTen
 import com.tspoon.traceur.Traceur
 import org.resolvetosavelives.red.di.AppComponent
@@ -18,8 +19,11 @@ abstract class RedApp : Application() {
     if (BuildConfig.DEBUG) {
       Timber.plant(Timber.DebugTree())
       Traceur.enableLogging()
+      Stetho.initializeWithDefaults(this)
     }
+
     LazyThreeTen.init(this)
+
     appComponent = buildDaggerGraph()
   }
 

--- a/app/src/main/java/org/resolvetosavelives/red/ReleaseRedApp.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/ReleaseRedApp.kt
@@ -17,6 +17,7 @@ class ReleaseRedApp : RedApp() {
     super.onCreate()
 
     appComponent.inject(this)
+
     syncScheduler.schedule().subscribe()
   }
 

--- a/app/src/main/java/org/resolvetosavelives/red/di/TheActivityComponent.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/di/TheActivityComponent.kt
@@ -8,7 +8,7 @@ import org.resolvetosavelives.red.newentry.PatientEntryScreen
 import org.resolvetosavelives.red.newentry.success.PatientSavedScreen
 import org.resolvetosavelives.red.qrscan.AadhaarScanScreen
 import org.resolvetosavelives.red.router.screen.ScreenRouter
-import org.resolvetosavelives.red.search.PatientSearchByPhoneScreen
+import org.resolvetosavelives.red.search.PatientSearchScreen
 
 @Subcomponent
 interface TheActivityComponent {
@@ -16,7 +16,7 @@ interface TheActivityComponent {
   fun inject(target: NewBpScreen)
   fun inject(target: TheActivity)
   fun inject(target: PatientSavedScreen)
-  fun inject(target: PatientSearchByPhoneScreen)
+  fun inject(target: PatientSearchScreen)
   fun inject(target: AadhaarScanScreen)
   fun inject(target: PatientEntryScreen)
 

--- a/app/src/main/java/org/resolvetosavelives/red/home/bp/NewBpScreen.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/home/bp/NewBpScreen.kt
@@ -10,7 +10,7 @@ import io.reactivex.schedulers.Schedulers.io
 import kotterknife.bindView
 import org.resolvetosavelives.red.R
 import org.resolvetosavelives.red.TheActivity
-import org.resolvetosavelives.red.search.PatientSearchByPhoneScreen
+import org.resolvetosavelives.red.search.PatientSearchScreen
 import org.resolvetosavelives.red.router.screen.ScreenRouter
 import javax.inject.Inject
 
@@ -45,6 +45,6 @@ open class NewBpScreen(context: Context, attrs: AttributeSet) : RelativeLayout(c
   }
 
   fun openNewPatientScreen() {
-    screenRouter.push(PatientSearchByPhoneScreen.KEY)
+    screenRouter.push(PatientSearchScreen.KEY)
   }
 }

--- a/app/src/main/java/org/resolvetosavelives/red/patient/PatientRepository.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/patient/PatientRepository.kt
@@ -21,15 +21,13 @@ class PatientRepository @Inject constructor(private val database: AppDatabase) {
 
   private var ongoingPatientEntry: OngoingPatientEntry = OngoingPatientEntry()
 
-  @Deprecated(message = "Use searchPatientsWithAddressesAndPhoneNumbers() instead", replaceWith = ReplaceWith("searchPatientsWithAddressesAndPhoneNumbers(query)"))
-  fun searchPatients(query: String): Observable<List<Patient>> {
+  fun searchPatientsAndPhoneNumbers(query: String): Observable<List<PatientSearchResult>> {
     if (query.isEmpty()) {
-      return database.patientDao()
-          .allPatients()
+      return database.patientSearchDao()
+          .allRecords()
           .toObservable()
     }
-
-    return database.patientDao()
+    return database.patientSearchDao()
         .search(query)
         .toObservable()
   }
@@ -38,18 +36,6 @@ class PatientRepository @Inject constructor(private val database: AppDatabase) {
     return database.patientDao()
         .patientCount()
         .firstOrError()
-  }
-
-  fun searchPatientsWithAddressesAndPhoneNumbers(query: String): Observable<List<PatientWithAddressAndPhone>> {
-    if (query.isEmpty()) {
-      return database.patientAddressPhoneDao()
-          .allRecords()
-          .toObservable()
-    }
-
-    return database.patientAddressPhoneDao()
-        .search(query)
-        .toObservable()
   }
 
   fun patientsWithSyncStatus(status: SyncStatus): Single<List<PatientWithAddressAndPhone>> {

--- a/app/src/main/java/org/resolvetosavelives/red/patient/PatientSearchResult.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/patient/PatientSearchResult.kt
@@ -35,6 +35,8 @@ data class PatientSearchResult(
 
     val phoneNumber: String?,
 
+    val phoneType: PatientPhoneNumberType?,
+
     val phoneActive: Boolean?
 ) {
 
@@ -47,10 +49,10 @@ data class PatientSearchResult(
           SELECT P.uuid, P.fullName, P.gender, P.dateOfBirth, P.age_value, P.age_updatedAt, P.status, P.createdAt, P.updatedAt, P.syncStatus,
           PA.uuid addr_uuid, PA.colonyOrVillage addr_colonyOrVillage, PA.district addr_district, PA.state addr_state, PA.country addr_country,
           PA.createdAt addr_createdAt, PA.updatedAt addr_updatedAt,
-          PP.number phoneNumber, PP.active phoneActive
+          PP.number phoneNumber, PP.phoneType phoneType, PP.active phoneActive
           FROM Patient P
           INNER JOIN PatientAddress PA on PA.uuid = P.addressUuid
-          INNER JOIN PatientPhoneNumber PP ON P.uuid = PP.patientUuid
+          LEFT JOIN PatientPhoneNumber PP ON PP.patientUuid = P.uuid
     """
     }
 

--- a/app/src/main/java/org/resolvetosavelives/red/patient/PatientSearchResult.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/patient/PatientSearchResult.kt
@@ -1,0 +1,63 @@
+package org.resolvetosavelives.red.patient
+
+import android.arch.persistence.room.Dao
+import android.arch.persistence.room.Embedded
+import android.arch.persistence.room.Query
+import io.reactivex.Flowable
+import org.intellij.lang.annotations.Language
+import org.threeten.bp.Instant
+import org.threeten.bp.LocalDate
+import java.util.UUID
+
+data class PatientSearchResult(
+
+    val uuid: UUID,
+
+    val fullName: String,
+
+    val gender: Gender,
+
+    val dateOfBirth: LocalDate?,
+
+    @Embedded(prefix = "age_")
+    val age: Age?,
+
+    val status: PatientStatus,
+
+    val createdAt: Instant,
+
+    val updatedAt: Instant,
+
+    val syncStatus: SyncStatus,
+
+    @Embedded(prefix = "addr_")
+    val address: PatientAddress,
+
+    val phoneNumber: String?,
+
+    val phoneActive: Boolean?
+) {
+
+  @Dao
+  interface RoomDao {
+
+    companion object {
+      @Language("RoomSql")
+      const val mainQuery = """
+          SELECT P.uuid, P.fullName, P.gender, P.dateOfBirth, P.age_value, P.age_updatedAt, P.status, P.createdAt, P.updatedAt, P.syncStatus,
+          PA.uuid addr_uuid, PA.colonyOrVillage addr_colonyOrVillage, PA.district addr_district, PA.state addr_state, PA.country addr_country,
+          PA.createdAt addr_createdAt, PA.updatedAt addr_updatedAt,
+          PP.number phoneNumber, PP.active phoneActive
+          FROM Patient P
+          INNER JOIN PatientAddress PA on PA.uuid = P.addressUuid
+          INNER JOIN PatientPhoneNumber PP ON P.uuid = PP.patientUuid
+    """
+    }
+
+    @Query("$mainQuery WHERE P.fullname LIKE '%' || :query || '%' OR PP.number LIKE '%' || :query || '%'")
+    fun search(query: String): Flowable<List<PatientSearchResult>>
+
+    @Query(mainQuery)
+    fun allRecords(): Flowable<List<PatientSearchResult>>
+  }
+}

--- a/app/src/main/java/org/resolvetosavelives/red/patient/PatientWithAddressAndPhone.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/patient/PatientWithAddressAndPhone.kt
@@ -39,9 +39,10 @@ data class PatientWithAddressAndPhone(
 ) {
 
   @Relation(parentColumn = "uuid", entityColumn = "patientUuid")
-  lateinit var phoneNumbers: List<PatientPhoneNumber>
+  var phoneNumbers: List<PatientPhoneNumber>? = null
 
   fun toPayload(): PatientPayload {
+    // TODO: Add phone numbers to this payload
     return PatientPayload(
         uuid = uuid,
         fullName = fullName,
@@ -81,11 +82,11 @@ data class PatientWithAddressAndPhone(
     }
 
     @Transaction
-    @Query("$joinQuery WHERE fullName LIKE '%' || :query || '%'")
+    @Query("$joinQuery WHERE P.fullName LIKE '%' || :query || '%'")
     fun search(query: String): Flowable<List<PatientWithAddressAndPhone>>
 
     @Transaction
-    @Query("$joinQuery")
+    @Query(joinQuery)
     fun allRecords(): Flowable<List<PatientWithAddressAndPhone>>
 
     @Transaction

--- a/app/src/main/java/org/resolvetosavelives/red/patient/sync/PatientSync.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/patient/sync/PatientSync.kt
@@ -41,6 +41,7 @@ class PatientSync @Inject constructor(
           repository.updatePatientsSyncStatus(oldStatus = SyncStatus.PENDING, newStatus = SyncStatus.IN_FLIGHT)
         }
 
+    // TODO: Add phone numbers here
     val networkCall = cachedPendingSyncPatients
         .map { patients -> patients.map { it.toPayload() } }
         .map(::PatientPushRequest)
@@ -69,6 +70,7 @@ class PatientSync @Inject constructor(
   }
 
   fun pull(): Completable {
+    // TODO: Add phone numbers here
     return configProvider
         .flatMapCompletable { config ->
           lastPullTimestamp.asObservable()

--- a/app/src/main/java/org/resolvetosavelives/red/search/BackButtonClicked.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/BackButtonClicked.kt
@@ -1,0 +1,5 @@
+package org.resolvetosavelives.red.search
+
+import org.resolvetosavelives.red.widgets.UiEvent
+
+class BackButtonClicked : UiEvent

--- a/app/src/main/java/org/resolvetosavelives/red/search/CreateNewPatientClicked.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/CreateNewPatientClicked.kt
@@ -2,4 +2,4 @@ package org.resolvetosavelives.red.search
 
 import org.resolvetosavelives.red.widgets.UiEvent
 
-class PatientSearchProceedClicked : UiEvent
+class CreateNewPatientClicked : UiEvent

--- a/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchProceedClicked.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchProceedClicked.kt
@@ -2,4 +2,4 @@ package org.resolvetosavelives.red.search
 
 import org.resolvetosavelives.red.widgets.UiEvent
 
-class PatientSearchByPhoneProceedClicked : UiEvent
+class PatientSearchProceedClicked : UiEvent

--- a/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchResultsAdapter.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchResultsAdapter.kt
@@ -54,7 +54,7 @@ class PatientSearchResultsAdapter : RecyclerView.Adapter<PatientSearchResultsAda
 
       if (patient.age == null) {
         val years = Period.between(patient.dateOfBirth, LocalDate.now()).years.toString()
-        ageTextView.text = itemView.context.getString(R.string.patient_age, years)
+        ageTextView.text = itemView.context.getString(R.string.patientsearch_age, years)
 
       } else {
         val ageUpdatedAt = LocalDateTime.ofInstant(patient.age.updatedAt, ZoneOffset.UTC)
@@ -63,7 +63,7 @@ class PatientSearchResultsAdapter : RecyclerView.Adapter<PatientSearchResultsAda
 
         val oldAge = patient.age.value
         val currentAge = oldAge + yearsSinceThen
-        ageTextView.text = itemView.context.getString(R.string.patient_age, currentAge.toString())
+        ageTextView.text = itemView.context.getString(R.string.patientsearch_age, currentAge.toString())
       }
 
       if (patient.phoneNumber?.isNotEmpty() == true) {

--- a/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchResultsAdapter.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchResultsAdapter.kt
@@ -8,6 +8,10 @@ import android.widget.TextView
 import kotterknife.bindView
 import org.resolvetosavelives.red.R
 import org.resolvetosavelives.red.patient.PatientSearchResult
+import org.threeten.bp.LocalDate
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.Period
+import org.threeten.bp.ZoneOffset
 
 class PatientSearchResultsAdapter : RecyclerView.Adapter<PatientSearchResultsAdapter.ViewHolder>() {
 
@@ -19,6 +23,7 @@ class PatientSearchResultsAdapter : RecyclerView.Adapter<PatientSearchResultsAda
   }
 
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+
     val inflater = LayoutInflater.from(parent.context)
     return ViewHolder(inflater.inflate(R.layout.list_patient_search, parent, false))
   }
@@ -34,6 +39,7 @@ class PatientSearchResultsAdapter : RecyclerView.Adapter<PatientSearchResultsAda
   class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
     private val titleTextView by bindView<TextView>(R.id.patientsearch_item_title)
+    private val ageTextView by bindView<TextView>(R.id.patientsearch_item_age)
     private val bylineTextView by bindView<TextView>(R.id.patientsearch_item_byline)
 
     init {
@@ -45,6 +51,20 @@ class PatientSearchResultsAdapter : RecyclerView.Adapter<PatientSearchResultsAda
     fun render(patient: PatientSearchResult) {
       titleTextView.text = String.format("%s • %s", patient.fullName, patient.gender.toString().substring(0, 1))
       bylineTextView.text = String.format("%s, %s", patient.address.colonyOrVillage, patient.address.district)
+
+      if (patient.age == null) {
+        val years = Period.between(patient.dateOfBirth, LocalDate.now()).years.toString()
+        ageTextView.text = itemView.context.getString(R.string.patient_age, years)
+
+      } else {
+        val ageUpdatedAt = LocalDateTime.ofInstant(patient.age.updatedAt, ZoneOffset.UTC)
+        val updatedAtLocalDate = LocalDate.of(ageUpdatedAt.year, ageUpdatedAt.month, ageUpdatedAt.dayOfMonth)
+        val yearsSinceThen = Period.between(updatedAtLocalDate, LocalDate.now()).years
+
+        val oldAge = patient.age.value
+        val currentAge = oldAge + yearsSinceThen
+        ageTextView.text = itemView.context.getString(R.string.patient_age, currentAge.toString())
+      }
 
       if (patient.phoneNumber?.isNotEmpty() == true) {
         val current = bylineTextView.text

--- a/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchResultsAdapter.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchResultsAdapter.kt
@@ -7,13 +7,13 @@ import android.view.ViewGroup
 import android.widget.TextView
 import kotterknife.bindView
 import org.resolvetosavelives.red.R
-import org.resolvetosavelives.red.patient.Patient
+import org.resolvetosavelives.red.patient.PatientSearchResult
 
 class PatientSearchResultsAdapter : RecyclerView.Adapter<PatientSearchResultsAdapter.ViewHolder>() {
 
-  private var patients: List<Patient>? = null
+  private var patients: List<PatientSearchResult>? = null
 
-  fun updateAndNotifyChanges(patients: List<Patient>) {
+  fun updateAndNotifyChanges(patients: List<PatientSearchResult>) {
     this.patients = patients
     notifyDataSetChanged()
   }
@@ -28,11 +28,11 @@ class PatientSearchResultsAdapter : RecyclerView.Adapter<PatientSearchResultsAda
   }
 
   override fun getItemCount(): Int {
-    return patients?.size
-        ?: 0
+    return patients?.size ?: 0
   }
 
   class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+
     private val titleTextView by bindView<TextView>(R.id.patientsearch_item_title)
     private val bylineTextView by bindView<TextView>(R.id.patientsearch_item_byline)
 
@@ -42,18 +42,14 @@ class PatientSearchResultsAdapter : RecyclerView.Adapter<PatientSearchResultsAda
       })
     }
 
-    fun render(patient: Patient) {
-      if (patient.fullName.isNotBlank()) {
-        titleTextView.text = patient.fullName
-      } else {
-        titleTextView.text = "(no name)"
-      }
+    fun render(patient: PatientSearchResult) {
+      titleTextView.text = String.format("%s • %s", patient.fullName, patient.gender.toString().substring(0, 1))
+      bylineTextView.text = String.format("%s, %s", patient.address.colonyOrVillage, patient.address.district)
 
-//      if (patient.phoneNumbers.primary.isNotBlank()) {
-//        bylineTextView.text = patient.phoneNumbers.primary
-//      } else {
-//        bylineTextView.text = "(no number)"
-//      }
+      if (patient.phoneNumber?.isNotEmpty() == true) {
+        val current = bylineTextView.text
+        bylineTextView.text = String.format("%s | $current", patient.phoneNumber)
+      }
     }
   }
 }

--- a/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreen.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreen.kt
@@ -43,9 +43,10 @@ class PatientSearchScreen(context: Context, attrs: AttributeSet) : RelativeLayou
     if (isInEditMode) {
       return
     }
+
     TheActivity.component.inject(this)
 
-    Observable.merge(phoneNumberTextChanges(), proceedButtonClicks())
+    Observable.merge(phoneNumberTextChanges(), newPatientButtonClicks())
         .observeOn(io())
         .compose(controller)
         .observeOn(mainThread())
@@ -57,8 +58,8 @@ class PatientSearchScreen(context: Context, attrs: AttributeSet) : RelativeLayou
       .map(CharSequence::toString)
       .map(::PatientPhoneNumberTextChanged)
 
-  private fun proceedButtonClicks() = RxView.clicks(newPatientButton)
-      .map { PatientSearchProceedClicked() }
+  private fun newPatientButtonClicks() = RxView.clicks(newPatientButton)
+      .map { CreateNewPatientClicked() }
 
   fun showKeyboardOnPhoneNumberField() {
     searchEditText.showKeyboard()

--- a/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreen.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreen.kt
@@ -16,7 +16,7 @@ import kotterknife.bindView
 import org.resolvetosavelives.red.R
 import org.resolvetosavelives.red.TheActivity
 import org.resolvetosavelives.red.newentry.PatientEntryScreen
-import org.resolvetosavelives.red.patient.Patient
+import org.resolvetosavelives.red.patient.PatientSearchResult
 import org.resolvetosavelives.red.router.screen.ScreenRouter
 import org.resolvetosavelives.red.widgets.showKeyboard
 import javax.inject.Inject
@@ -46,7 +46,7 @@ class PatientSearchScreen(context: Context, attrs: AttributeSet) : RelativeLayou
 
     TheActivity.component.inject(this)
 
-    Observable.merge(phoneNumberTextChanges(), newPatientButtonClicks())
+    Observable.merge(searchTextChanges(), newPatientButtonClicks())
         .observeOn(io())
         .compose(controller)
         .observeOn(mainThread())
@@ -54,9 +54,9 @@ class PatientSearchScreen(context: Context, attrs: AttributeSet) : RelativeLayou
         .subscribe { uiChange -> uiChange(this) }
   }
 
-  private fun phoneNumberTextChanges() = RxTextView.textChanges(searchEditText)
+  private fun searchTextChanges() = RxTextView.textChanges(searchEditText)
       .map(CharSequence::toString)
-      .map(::PatientPhoneNumberTextChanged)
+      .map(::SearchQueryTextChanged)
 
   private fun newPatientButtonClicks() = RxView.clicks(newPatientButton)
       .map { CreateNewPatientClicked() }
@@ -70,7 +70,7 @@ class PatientSearchScreen(context: Context, attrs: AttributeSet) : RelativeLayou
     patientRecyclerView.layoutManager = LinearLayoutManager(context)
   }
 
-  fun updatePatientSearchResults(patients: List<Patient>) {
+  fun updatePatientSearchResults(patients: List<PatientSearchResult>) {
     resultsAdapter.updateAndNotifyChanges(patients)
   }
 

--- a/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreen.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreen.kt
@@ -21,19 +21,19 @@ import org.resolvetosavelives.red.router.screen.ScreenRouter
 import org.resolvetosavelives.red.widgets.showKeyboard
 import javax.inject.Inject
 
-class PatientSearchByPhoneScreen(context: Context, attrs: AttributeSet) : RelativeLayout(context, attrs) {
+class PatientSearchScreen(context: Context, attrs: AttributeSet) : RelativeLayout(context, attrs) {
 
   companion object {
-    val KEY = PatientSearchByPhoneScreenKey()
+    val KEY = PatientSearchScreenKey()
   }
 
   @Inject
   lateinit var screenRouter: ScreenRouter
 
   @Inject
-  lateinit var controller: PatientSearchByPhoneScreenController
+  lateinit var controller: PatientSearchScreenController
 
-  private val phoneNumberEditText by bindView<EditText>(R.id.patientsearch_phone_number)
+  private val searchEditText by bindView<EditText>(R.id.patientsearch_text)
   private val newPatientButton by bindView<Button>(R.id.patientsearch_new_patient)
   private val patientRecyclerView by bindView<RecyclerView>(R.id.patientsearch_recyclerview)
   private val resultsAdapter = PatientSearchResultsAdapter()
@@ -53,15 +53,15 @@ class PatientSearchByPhoneScreen(context: Context, attrs: AttributeSet) : Relati
         .subscribe { uiChange -> uiChange(this) }
   }
 
-  private fun phoneNumberTextChanges() = RxTextView.textChanges(phoneNumberEditText)
+  private fun phoneNumberTextChanges() = RxTextView.textChanges(searchEditText)
       .map(CharSequence::toString)
       .map(::PatientPhoneNumberTextChanged)
 
   private fun proceedButtonClicks() = RxView.clicks(newPatientButton)
-      .map { PatientSearchByPhoneProceedClicked() }
+      .map { PatientSearchProceedClicked() }
 
   fun showKeyboardOnPhoneNumberField() {
-    phoneNumberEditText.showKeyboard()
+    searchEditText.showKeyboard()
   }
 
   fun setupSearchResultsList() {

--- a/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreen.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreen.kt
@@ -6,6 +6,7 @@ import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
 import android.widget.Button
 import android.widget.EditText
+import android.widget.ImageButton
 import android.widget.RelativeLayout
 import com.jakewharton.rxbinding2.view.RxView
 import com.jakewharton.rxbinding2.widget.RxTextView
@@ -33,6 +34,7 @@ class PatientSearchScreen(context: Context, attrs: AttributeSet) : RelativeLayou
   @Inject
   lateinit var controller: PatientSearchScreenController
 
+  private val backButton by bindView<ImageButton>(R.id.patientsearch_back)
   private val searchEditText by bindView<EditText>(R.id.patientsearch_text)
   private val newPatientButton by bindView<Button>(R.id.patientsearch_new_patient)
   private val patientRecyclerView by bindView<RecyclerView>(R.id.patientsearch_recyclerview)
@@ -46,7 +48,8 @@ class PatientSearchScreen(context: Context, attrs: AttributeSet) : RelativeLayou
 
     TheActivity.component.inject(this)
 
-    Observable.merge(searchTextChanges(), newPatientButtonClicks())
+    // TODO: Can we use sealed classes to represent events?
+    Observable.merge(searchTextChanges(), newPatientButtonClicks(), backButtonClicks())
         .observeOn(io())
         .compose(controller)
         .observeOn(mainThread())
@@ -60,6 +63,9 @@ class PatientSearchScreen(context: Context, attrs: AttributeSet) : RelativeLayou
 
   private fun newPatientButtonClicks() = RxView.clicks(newPatientButton)
       .map { CreateNewPatientClicked() }
+
+  private fun backButtonClicks() = RxView.clicks(backButton)
+      .map { BackButtonClicked() }
 
   fun showKeyboardOnPhoneNumberField() {
     searchEditText.showKeyboard()
@@ -76,5 +82,9 @@ class PatientSearchScreen(context: Context, attrs: AttributeSet) : RelativeLayou
 
   fun openPersonalDetailsEntryScreen() {
     screenRouter.push(PatientEntryScreen.KEY)
+  }
+
+  fun goBackToHomeScreen() {
+    screenRouter.pop()
   }
 }

--- a/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreenController.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreenController.kt
@@ -31,16 +31,16 @@ class PatientSearchScreenController @Inject constructor(
 
   private fun patientSearchResults(events: Observable<UiEvent>): Observable<UiChange> {
     return events
-        .ofType(PatientPhoneNumberTextChanged::class.java)
-        .map(PatientPhoneNumberTextChanged::number)
-        .flatMap { repository.searchPatients(it) }
+        .ofType(SearchQueryTextChanged::class.java)
+        .map(SearchQueryTextChanged::number)
+        .flatMap { repository.searchPatientsAndPhoneNumbers(it) }
         .map { matchingPatients -> { ui: Ui -> ui.updatePatientSearchResults(matchingPatients) } }
   }
 
   private fun saveAndProceeds(events: Observable<UiEvent>): Observable<UiChange> {
     val phoneNumberChanges = events
-        .ofType(PatientPhoneNumberTextChanged::class.java)
-        .map(PatientPhoneNumberTextChanged::number)
+        .ofType(SearchQueryTextChanged::class.java)
+        .map(SearchQueryTextChanged::number)
 
     return events
         .ofType(CreateNewPatientClicked::class.java)

--- a/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreenController.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreenController.kt
@@ -22,7 +22,8 @@ class PatientSearchScreenController @Inject constructor(
     return Observable.merge(
         screenSetup(),
         patientSearchResults(replayedEvents),
-        saveAndProceeds(replayedEvents))
+        saveAndProceeds(replayedEvents),
+        backButtonClicks(replayedEvents))
   }
 
   private fun screenSetup(): Observable<UiChange> {
@@ -49,5 +50,10 @@ class PatientSearchScreenController @Inject constructor(
         .map { number -> OngoingPatientEntry(phoneNumber = OngoingPatientEntry.PhoneNumber(number)) }
         .flatMapCompletable { newEntry -> repository.saveOngoingEntry(newEntry) }
         .andThen(Observable.just { ui: Ui -> ui.openPersonalDetailsEntryScreen() })
+  }
+
+  private fun backButtonClicks(events: Observable<UiEvent>): Observable<UiChange> {
+    return events.ofType(BackButtonClicked::class.java)
+        .map { { ui: Ui -> ui.goBackToHomeScreen() } }
   }
 }

--- a/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreenController.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreenController.kt
@@ -9,10 +9,10 @@ import org.resolvetosavelives.red.patient.PatientRepository
 import org.resolvetosavelives.red.widgets.UiEvent
 import javax.inject.Inject
 
-private typealias Ui = PatientSearchByPhoneScreen
+private typealias Ui = PatientSearchScreen
 private typealias UiChange = (Ui) -> Unit
 
-class PatientSearchByPhoneScreenController @Inject constructor(
+class PatientSearchScreenController @Inject constructor(
     private val repository: PatientRepository
 ) : ObservableTransformer<UiEvent, UiChange> {
 
@@ -43,7 +43,7 @@ class PatientSearchByPhoneScreenController @Inject constructor(
         .map(PatientPhoneNumberTextChanged::number)
 
     return events
-        .ofType(PatientSearchByPhoneProceedClicked::class.java)
+        .ofType(PatientSearchProceedClicked::class.java)
         .withLatestFrom(phoneNumberChanges, { _, number -> number })
         .take(1)
         .map { number -> OngoingPatientEntry(phoneNumber = OngoingPatientEntry.PhoneNumber(number)) }

--- a/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreenController.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreenController.kt
@@ -43,7 +43,7 @@ class PatientSearchScreenController @Inject constructor(
         .map(PatientPhoneNumberTextChanged::number)
 
     return events
-        .ofType(PatientSearchProceedClicked::class.java)
+        .ofType(CreateNewPatientClicked::class.java)
         .withLatestFrom(phoneNumberChanges, { _, number -> number })
         .take(1)
         .map { number -> OngoingPatientEntry(phoneNumber = OngoingPatientEntry.PhoneNumber(number)) }

--- a/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreenController.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreenController.kt
@@ -33,7 +33,7 @@ class PatientSearchScreenController @Inject constructor(
   private fun patientSearchResults(events: Observable<UiEvent>): Observable<UiChange> {
     return events
         .ofType(SearchQueryTextChanged::class.java)
-        .map(SearchQueryTextChanged::number)
+        .map(SearchQueryTextChanged::query)
         .flatMap { repository.searchPatientsAndPhoneNumbers(it) }
         .map { matchingPatients -> { ui: Ui -> ui.updatePatientSearchResults(matchingPatients) } }
   }
@@ -41,7 +41,7 @@ class PatientSearchScreenController @Inject constructor(
   private fun saveAndProceeds(events: Observable<UiEvent>): Observable<UiChange> {
     val phoneNumberChanges = events
         .ofType(SearchQueryTextChanged::class.java)
-        .map(SearchQueryTextChanged::number)
+        .map(SearchQueryTextChanged::query)
 
     return events
         .ofType(CreateNewPatientClicked::class.java)

--- a/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreenKey.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreenKey.kt
@@ -5,7 +5,7 @@ import org.resolvetosavelives.red.R
 import org.resolvetosavelives.red.router.screen.FullScreenKey
 
 @Parcelize
-class PatientSearchByPhoneScreenKey : FullScreenKey {
+class PatientSearchScreenKey : FullScreenKey {
 
   override fun layoutRes(): Int {
     return R.layout.screen_patient_search_by_phone

--- a/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreenKey.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/PatientSearchScreenKey.kt
@@ -8,6 +8,6 @@ import org.resolvetosavelives.red.router.screen.FullScreenKey
 class PatientSearchScreenKey : FullScreenKey {
 
   override fun layoutRes(): Int {
-    return R.layout.screen_patient_search_by_phone
+    return R.layout.screen_patient_search
   }
 }

--- a/app/src/main/java/org/resolvetosavelives/red/search/SearchQueryTextChanged.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/SearchQueryTextChanged.kt
@@ -2,4 +2,4 @@ package org.resolvetosavelives.red.search
 
 import org.resolvetosavelives.red.widgets.UiEvent
 
-data class PatientPhoneNumberTextChanged(val number: String) : UiEvent
+data class SearchQueryTextChanged(val number: String) : UiEvent

--- a/app/src/main/java/org/resolvetosavelives/red/search/SearchQueryTextChanged.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/search/SearchQueryTextChanged.kt
@@ -2,4 +2,4 @@ package org.resolvetosavelives.red.search
 
 import org.resolvetosavelives.red.widgets.UiEvent
 
-data class SearchQueryTextChanged(val number: String) : UiEvent
+data class SearchQueryTextChanged(val query: String) : UiEvent

--- a/app/src/main/java/org/resolvetosavelives/red/util/RoomEnumTypeConverter.kt
+++ b/app/src/main/java/org/resolvetosavelives/red/util/RoomEnumTypeConverter.kt
@@ -5,13 +5,16 @@ import android.arch.persistence.room.TypeConverter
 abstract class RoomEnumTypeConverter<T : Enum<T>>(private val enumClass: Class<T>) {
 
   @TypeConverter
-  fun toEnum(serialized: String): T {
+  fun toEnum(serialized: String?): T? {
+    if (serialized.isNullOrEmpty()) {
+      return null
+    }
     return java.lang.Enum.valueOf(asEnumClass<T>(enumClass), serialized)
   }
 
   @TypeConverter
-  fun fromEnum(value: T): String {
-    return value.name
+  fun fromEnum(value: T?): String? {
+    return value?.name
   }
 
   /* This weirdness https://discuss.kotlinlang.org/t/confusing-type-error/506/8 */

--- a/app/src/main/res/drawable/ic_add_circle_outline_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_add_circle_outline_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#4F4DE7"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M13,7h-2v4L7,11v2h4v4h2v-4h4v-2h-4L13,7zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_arrow_back_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_arrow_back_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#757575"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/app/src/main/res/layout/list_patient_search.xml
+++ b/app/src/main/res/layout/list_patient_search.xml
@@ -3,27 +3,42 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
-  android:background="?attr/selectableItemBackground"
-  android:orientation="vertical"
+  android:paddingTop="@dimen/spacing_8"
   android:paddingBottom="@dimen/spacing_8"
-  android:paddingEnd="@dimen/spacing_16"
   android:paddingStart="@dimen/spacing_16"
-  android:paddingTop="@dimen/spacing_8">
+  android:paddingEnd="@dimen/spacing_16"
+  android:background="?attr/selectableItemBackground"
+  android:orientation="vertical">
 
-  <TextView
-    android:id="@+id/patientsearch_item_title"
+  <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:ellipsize="end"
-    android:maxLines="1"
-    android:textColor="@color/color_accent"
-    tools:text="Anshu Acharya, 39, female" />
+    android:orientation="horizontal">
 
+    <TextView
+      android:id="@+id/patientsearch_item_title"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_weight="1"
+      android:ellipsize="end"
+      android:maxLines="1"
+      android:textColor="@color/color_accent"
+      tools:text="Anshu Acharya, 39, female" />
+
+    <TextView
+      android:id="@+id/patientsearch_item_age"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:maxLines="1"
+      android:textColor="@color/gray_950"
+      tools:text="Age: 42" />
+  </LinearLayout>
   <TextView
     android:id="@+id/patientsearch_item_byline"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:ellipsize="end"
     android:maxLines="1"
+    android:textColor="@color/gray_950"
     tools:text="55 Mansing Road, Colony 3, Hoshiarpur" />
 </LinearLayout>

--- a/app/src/main/res/layout/screen_patient_search.xml
+++ b/app/src/main/res/layout/screen_patient_search.xml
@@ -26,6 +26,8 @@
       android:id="@+id/patientsearch_text"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:layout_marginStart="@dimen/spacing_16"
+      android:layout_marginEnd="@dimen/spacing_16"
       android:background="@null"
       android:hint="@string/patientsearch_name_or_phone"
       android:inputType="text">

--- a/app/src/main/res/layout/screen_patient_search.xml
+++ b/app/src/main/res/layout/screen_patient_search.xml
@@ -42,16 +42,14 @@
     android:layout_below="@id/patientsearch_toolbar"
     android:contentDescription="@string/patientsearch_new_patient"
     android:drawableStart="@drawable/ic_add_circle_outline_black_24dp"
-    android:text="@string/patientsearch_new_patient" />
+    android:text="@string/patientsearch_new_patient"
+    android:visibility="gone" />
 
   <android.support.v7.widget.RecyclerView
     android:id="@+id/patientsearch_recyclerview"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_below="@id/patientsearch_new_patient"
-    android:paddingTop="@dimen/spacing_8"
-    android:paddingBottom="@dimen/spacing_8"
-    android:clipToPadding="false"
     tools:listitem="@layout/list_patient_search" />
 
 </org.resolvetosavelives.red.search.PatientSearchScreen>

--- a/app/src/main/res/layout/screen_patient_search_by_phone.xml
+++ b/app/src/main/res/layout/screen_patient_search_by_phone.xml
@@ -17,8 +17,7 @@
       android:id="@+id/patientsearch_back"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_marginStart="@dimen/spacing_8"
-      android:layout_marginEnd="@dimen/spacing_8"
+      android:layout_marginEnd="@dimen/spacing_16"
       android:background="?attr/selectableItemBackgroundBorderless"
       android:contentDescription="@string/patientsearch_go_back"
       android:src="@drawable/ic_arrow_back_black_24dp" />
@@ -35,23 +34,24 @@
     </EditText>
   </android.support.v7.widget.Toolbar>
 
+  <Button
+    android:id="@+id/patientsearch_new_patient"
+    style="@style/RedApp.Button.PatientEntry"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_below="@id/patientsearch_toolbar"
+    android:contentDescription="@string/patientsearch_new_patient"
+    android:drawableStart="@drawable/ic_add_circle_outline_black_24dp"
+    android:text="@string/patientsearch_new_patient" />
+
   <android.support.v7.widget.RecyclerView
     android:id="@+id/patientsearch_recyclerview"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_below="@id/patientsearch_toolbar"
+    android:layout_below="@id/patientsearch_new_patient"
     android:paddingTop="@dimen/spacing_8"
     android:paddingBottom="@dimen/spacing_8"
     android:clipToPadding="false"
     tools:listitem="@layout/list_patient_search" />
 
-  <Button
-    android:id="@+id/patientsearch_new_patient"
-    style="@style/RedApp.Button.PatientEntry"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_margin="@dimen/spacing_12"
-    android:layout_alignParentBottom="true"
-    android:layout_alignParentEnd="true"
-    android:text="@string/patientsearch_new_patient" />
 </org.resolvetosavelives.red.search.PatientSearchScreen>

--- a/app/src/main/res/layout/screen_patient_search_by_phone.xml
+++ b/app/src/main/res/layout/screen_patient_search_by_phone.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<org.resolvetosavelives.red.search.PatientSearchByPhoneScreen android:id="@+id/patientsearch_root"
-  xmlns:android="http://schemas.android.com/apk/res/android"
+<org.resolvetosavelives.red.search.PatientSearchScreen xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/patientsearch_root"
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
@@ -10,16 +10,26 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/white"
-    android:elevation="2dp"
+    android:elevation="4dp"
     tools:ignore="UnusedAttribute">
 
+    <ImageButton
+      android:id="@+id/patientsearch_back"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="@dimen/spacing_8"
+      android:layout_marginEnd="@dimen/spacing_8"
+      android:background="?attr/selectableItemBackgroundBorderless"
+      android:contentDescription="@string/patientsearch_go_back"
+      android:src="@drawable/ic_arrow_back_black_24dp" />
+
     <EditText
-      android:id="@+id/patientsearch_phone_number"
+      android:id="@+id/patientsearch_text"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:background="@null"
-      android:hint="@string/patientsearch_search_field_hint"
-      android:inputType="phone">
+      android:hint="@string/patientsearch_name_or_phone"
+      android:inputType="text">
 
       <requestFocus />
     </EditText>
@@ -30,9 +40,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_below="@id/patientsearch_toolbar"
-    android:clipToPadding="false"
-    android:paddingBottom="@dimen/spacing_8"
     android:paddingTop="@dimen/spacing_8"
+    android:paddingBottom="@dimen/spacing_8"
+    android:clipToPadding="false"
     tools:listitem="@layout/list_patient_search" />
 
   <Button
@@ -40,8 +50,8 @@
     style="@style/RedApp.Button.PatientEntry"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:layout_margin="@dimen/spacing_12"
     android:layout_alignParentBottom="true"
     android:layout_alignParentEnd="true"
-    android:layout_margin="@dimen/spacing_12"
     android:text="@string/patientsearch_new_patient" />
-</org.resolvetosavelives.red.search.PatientSearchByPhoneScreen>
+</org.resolvetosavelives.red.search.PatientSearchScreen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,7 +5,6 @@
   <dimen name="spacing_8">8dp</dimen>
   <dimen name="spacing_12">12dp</dimen>
   <dimen name="spacing_16">16dp</dimen>
-  <dimen name="spacing_20">20dp</dimen>
   <dimen name="spacing_24">24dp</dimen>
 
   <dimen name="textsize_16">16sp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
   <string name="app_name">RedApp</string>
 
   <!-- Patient search -->
-  <string name="patientsearch_new_patient">New patient</string>
+  <string name="patientsearch_new_patient">Create new patient</string>
   <string name="patientsearch_go_back">Go back to home screen</string>
   <string name="patientsearch_name_or_phone">Patient\'s name or phone</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
   <string name="patientsearch_new_patient">Create new patient</string>
   <string name="patientsearch_go_back">Go back to home screen</string>
   <string name="patientsearch_name_or_phone">Patient\'s name or phone</string>
+  <string name="patient_age">Age: %s</string>
 
   <!-- Manual patient entry -->
   <string name="patiententry_contentdescription_up_button">Go back to search</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
   <string name="patientsearch_new_patient">Create new patient</string>
   <string name="patientsearch_go_back">Go back to home screen</string>
   <string name="patientsearch_name_or_phone">Patient\'s name or phone</string>
-  <string name="patient_age">Age: %s</string>
+  <string name="patientsearch_age">Age: %s</string>
 
   <!-- Manual patient entry -->
   <string name="patiententry_contentdescription_up_button">Go back to search</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,9 +1,10 @@
 <resources>
   <string name="app_name">RedApp</string>
 
-  <!-- Lookup patients -->
+  <!-- Patient search -->
   <string name="patientsearch_new_patient">New patient</string>
-  <string name="patientsearch_search_field_hint">Enter patient\'s name or phone</string>
+  <string name="patientsearch_go_back">Go back to home screen</string>
+  <string name="patientsearch_name_or_phone">Patient\'s name or phone</string>
 
   <!-- Manual patient entry -->
   <string name="patiententry_contentdescription_up_button">Go back to search</string>
@@ -20,4 +21,5 @@
   <string name="patiententry_district">District</string>
   <string name="patiententry_state">State</string>
   <string name="patiententry_save_patient">Save patient</string>
+
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,9 +19,11 @@
   <style name="RedApp.Button" />
 
   <style name="RedApp.Button.PatientEntry">
-    <item name="android:textColor">@color/white</item>
-    <item name="backgroundTint">@color/color_accent</item>
-    <item name="android:paddingStart">@dimen/spacing_20</item>
-    <item name="android:paddingEnd">@dimen/spacing_20</item>
+    <item name="android:textColor">@color/color_accent</item>
+    <item name="android:gravity">start|center_vertical</item>
+    <item name="backgroundTint">#F2F4FB</item>
+    <item name="android:drawablePadding">@dimen/spacing_16</item>
+    <item name="android:paddingStart">@dimen/spacing_16</item>
+    <item name="android:paddingEnd">@dimen/spacing_16</item>
   </style>
 </resources>

--- a/app/src/test/java/org/resolvetosavelives/red/search/PatientSearchScreenControllerTest.kt
+++ b/app/src/test/java/org/resolvetosavelives/red/search/PatientSearchScreenControllerTest.kt
@@ -55,7 +55,7 @@ class PatientSearchScreenControllerTest {
     whenever(repository.saveOngoingEntry(any())).thenReturn(Completable.complete())
 
     uiEvents.onNext(PatientPhoneNumberTextChanged(partialNumber))
-    uiEvents.onNext(PatientSearchProceedClicked())
+    uiEvents.onNext(CreateNewPatientClicked())
 
     argumentCaptor<OngoingPatientEntry>().apply {
       verify(repository).saveOngoingEntry(capture())

--- a/app/src/test/java/org/resolvetosavelives/red/search/PatientSearchScreenControllerTest.kt
+++ b/app/src/test/java/org/resolvetosavelives/red/search/PatientSearchScreenControllerTest.kt
@@ -16,17 +16,17 @@ import org.resolvetosavelives.red.patient.Patient
 import org.resolvetosavelives.red.patient.PatientRepository
 import org.resolvetosavelives.red.widgets.UiEvent
 
-class PatientSearchByPhoneScreenControllerTest {
+class PatientSearchScreenControllerTest {
 
-  private val screen: PatientSearchByPhoneScreen = mock()
+  private val screen: PatientSearchScreen = mock()
   private val repository: PatientRepository = mock()
 
-  private lateinit var controller: PatientSearchByPhoneScreenController
+  private lateinit var controller: PatientSearchScreenController
   private val uiEvents = PublishSubject.create<UiEvent>()
 
   @Before
   fun setUp() {
-    controller = PatientSearchByPhoneScreenController(repository)
+    controller = PatientSearchScreenController(repository)
 
     uiEvents.compose(controller).subscribe { uiChange -> uiChange(screen) }
   }
@@ -55,7 +55,7 @@ class PatientSearchByPhoneScreenControllerTest {
     whenever(repository.saveOngoingEntry(any())).thenReturn(Completable.complete())
 
     uiEvents.onNext(PatientPhoneNumberTextChanged(partialNumber))
-    uiEvents.onNext(PatientSearchByPhoneProceedClicked())
+    uiEvents.onNext(PatientSearchProceedClicked())
 
     argumentCaptor<OngoingPatientEntry>().apply {
       verify(repository).saveOngoingEntry(capture())

--- a/app/src/test/java/org/resolvetosavelives/red/search/PatientSearchScreenControllerTest.kt
+++ b/app/src/test/java/org/resolvetosavelives/red/search/PatientSearchScreenControllerTest.kt
@@ -8,12 +8,11 @@ import com.nhaarman.mockito_kotlin.whenever
 import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
-import junit.framework.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.resolvetosavelives.red.patient.OngoingPatientEntry
-import org.resolvetosavelives.red.patient.Patient
 import org.resolvetosavelives.red.patient.PatientRepository
+import org.resolvetosavelives.red.patient.PatientSearchResult
 import org.resolvetosavelives.red.widgets.UiEvent
 
 class PatientSearchScreenControllerTest {
@@ -40,10 +39,10 @@ class PatientSearchScreenControllerTest {
   @Test
   fun `when phone number text changes then matching patients should be shown`() {
     val partialNumber = "999"
-    val matchingPatients = listOf<Patient>(mock(), mock(), mock())
-    whenever(repository.searchPatients(partialNumber)).thenReturn(Observable.just(matchingPatients))
+    val matchingPatients = listOf<PatientSearchResult>(mock(), mock(), mock())
+    whenever(repository.searchPatientsAndPhoneNumbers(partialNumber)).thenReturn(Observable.just(matchingPatients))
 
-    uiEvents.onNext(PatientPhoneNumberTextChanged(partialNumber))
+    uiEvents.onNext(SearchQueryTextChanged(partialNumber))
 
     verify(screen).updatePatientSearchResults(matchingPatients)
   }
@@ -51,15 +50,15 @@ class PatientSearchScreenControllerTest {
   @Test
   fun `when new patient is clicked then the manual entry flow should be started`() {
     val partialNumber = "999"
-    whenever(repository.searchPatients(partialNumber)).thenReturn(Observable.never())
+    whenever(repository.searchPatientsAndPhoneNumbers(partialNumber)).thenReturn(Observable.never())
     whenever(repository.saveOngoingEntry(any())).thenReturn(Completable.complete())
 
-    uiEvents.onNext(PatientPhoneNumberTextChanged(partialNumber))
+    uiEvents.onNext(SearchQueryTextChanged(partialNumber))
     uiEvents.onNext(CreateNewPatientClicked())
 
     argumentCaptor<OngoingPatientEntry>().apply {
       verify(repository).saveOngoingEntry(capture())
-      assertEquals(partialNumber, firstValue.phoneNumber!!.number)
+      assert(partialNumber == firstValue.phoneNumber!!.number)
     }
     verify(screen).openPersonalDetailsEntryScreen()
   }

--- a/app/src/test/java/org/resolvetosavelives/red/search/PatientSearchScreenControllerTest.kt
+++ b/app/src/test/java/org/resolvetosavelives/red/search/PatientSearchScreenControllerTest.kt
@@ -4,6 +4,7 @@ import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.argumentCaptor
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import io.reactivex.Completable
 import io.reactivex.Observable
@@ -34,6 +35,7 @@ class PatientSearchScreenControllerTest {
   fun `when screen starts then the keyboard should be shown on phone number field and patient list should be setup`() {
     verify(screen).showKeyboardOnPhoneNumberField()
     verify(screen).setupSearchResultsList()
+    verifyNoMoreInteractions(screen)
   }
 
   @Test
@@ -61,5 +63,12 @@ class PatientSearchScreenControllerTest {
       assert(partialNumber == firstValue.phoneNumber!!.number)
     }
     verify(screen).openPersonalDetailsEntryScreen()
+  }
+
+  @Test
+  fun `when back button is clicked, home screen should open`() {
+    uiEvents.onNext(BackButtonClicked())
+
+    verify(screen).goBackToHomeScreen()
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,8 @@ buildscript {
       butterKnife: '8.8.1',
       room       : '1.1.0',
       moshi      : '1.6.0',
-      retrofit   : '2.4.0'
+      retrofit   : '2.4.0',
+      stetho     : '1.5.0'
   ]
 
   repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ buildscript {
   repositories {
     google()
     jcenter()
+    maven { url 'https://jitpack.io' }
   }
 
   dependencies {

--- a/router/src/main/java/org/resolvetosavelives/red/router/screen/BaseViewGroupKeyChanger.kt
+++ b/router/src/main/java/org/resolvetosavelives/red/router/screen/BaseViewGroupKeyChanger.kt
@@ -13,8 +13,8 @@ import flow.TraversalCallback
 /**
  * Base class for key-changers that change screens in a single ViewGroup.
  *
- * @param <T> Type of key that this key-changer can handle. E.g., [FullScreenKey].
-</T> */
+ * @param [T] Type of key that this key-changer can handle. E.g., [FullScreenKey].
+ */
 abstract class BaseViewGroupKeyChanger<T : Any> : KeyChanger {
 
   override fun changeKey(

--- a/router/src/main/java/org/resolvetosavelives/red/router/screen/FullScreenKeyChanger.kt
+++ b/router/src/main/java/org/resolvetosavelives/red/router/screen/FullScreenKeyChanger.kt
@@ -7,9 +7,9 @@ import android.view.ViewGroup
 import flow.KeyChanger
 
 /**
- * Coordinates changes between {@link FullScreenKey FullScreenKeys}.
+ * Coordinates changes between [FullScreenKey]s.
  *
- * @param screenLayoutContainerRes ViewGroup where layouts for {@link FullScreenKey} will be inflated.
+ * @param [screenLayoutContainerRes] ViewGroup where layouts for [FullScreenKey] will be inflated.
  */
 class FullScreenKeyChanger(
     private val activity: Activity,


### PR DESCRIPTION
(Part of #6 and #7)

- Misc
  - [ ] Update the UI to match zeplin
  - [x] Update the search query to match name or phone numbers
  - [ ] If user selects a patient, open a dummy UI patient summary screen 
  - [x] If user clicks Back button, go back to the Home screen
- Age filter 
  - [ ] Make the UI in the toolbar
  - [ ] Update the query to show results with ±3 years of age entered
- Patient Sync API
  - [ ] Make sync push API call also send phone numbers
  - [ ] Make sync pull API call also retrieve and store phone numbers